### PR TITLE
Implement "/reconnect" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 A simple mod that supersedes [HiWord9](https://github.com/HiWord9)'s Reconnect Button mod, updated to support 1.21+!
 - This mod adds a reconnect button on your in-game menu screen while in a Multiplayer world.
+- **NEW**: You can also reconnect to a server by typing **_/reconnect_** in chat.
 
 ![Reconnect Mod: Reloaded Example](https://cdn.modrinth.com/data/PjzgKfEE/images/54a7871bc46040b5214402a13cbbd4ab58b64aec.png)
 
@@ -20,7 +21,7 @@ A simple mod that supersedes [HiWord9](https://github.com/HiWord9)'s Reconnect B
 - There are currently no plans of bringing this mod to Curseforge. For now this mod is available for download on [releases page](https://github.com/59xa/reconnect-mod-reloaded/releases/tag/Releases) or on [Modrinth](https://modrinth.com/mod/reconnect-mod-reloaded)
 
 ## Is this mod usable in Realms?
-- Due to how Mojang operates Realms, it is somewhat impossible to pinpoint the server address for any Realm world that you try to join.
+- Due to the Realms API being internal, it is impossible to pinpoint the server address for any Realm world that you try to join.
 - For the time being, using the reconnect button on Realms is not possible and has been disabled for use.
 
 ## Dependencies and Incompatibilities

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.7-SNAPSHOT'
+	id 'fabric-loom' version '1.10-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,14 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21
-yarn_mappings=1.21+build.9
-loader_version=0.15.11
+minecraft_version=1.21.5
+yarn_mappings=1.21.5+build.1
+loader_version=0.16.14
 
 # Mod Properties
-mod_version=1.1-1.21+
+mod_version=1.2-1.21.x
 maven_group=com.xand.reconnectmod
 archives_base_name=reconnect-mod-reloaded
 
 # Dependencies
-fabric_version=0.102.0+1.21
+fabric_version=0.121.0+1.21.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/xand/reconnectmod/ReconnectModReloaded.java
+++ b/src/main/java/com/xand/reconnectmod/ReconnectModReloaded.java
@@ -1,11 +1,17 @@
 package com.xand.reconnectmod;
 
-import net.fabricmc.api.ModInitializer;
-
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.multiplayer.ConnectScreen;
+import net.minecraft.client.network.ServerAddress;
+import net.minecraft.client.network.ServerInfo;
+import net.minecraft.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReconnectModReloaded implements ModInitializer {
+public class ReconnectModReloaded implements ClientModInitializer {
 	public static final String MOD_ID = "reconnectmod";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
@@ -14,7 +20,46 @@ public class ReconnectModReloaded implements ModInitializer {
 	public static final String ANSI_YELLOW = "\u001B[33m";
 
 	@Override
-	public void onInitialize() {
-		LOGGER.info(ANSI_GREEN + "Reconnect Mod Reloaded " + ANSI_YELLOW + "SUCCESSFULLY INITIALISED!");
+	public void onInitializeClient() {
+		LOGGER.info(ANSI_GREEN + "Reconnect Mod Reloaded " + ANSI_YELLOW + "SUCCESSFULLY INITIALIZED!");
+
+		// Register the /reconnect command
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, registryAccess) -> {
+			dispatcher.register(
+					ClientCommandManager.literal("reconnect")
+							.executes(context -> {
+								MinecraftClient client = MinecraftClient.getInstance();
+								ServerInfo currentServer = client.getCurrentServerEntry();
+
+								// Check if the current server is either singleplayer or multiplayer
+								if (currentServer == null) {
+									client.player.sendMessage(Text.of("RM-R: You are currently not connected to a multiplayer server."), false);
+									return 0;
+								}
+
+								if (currentServer.isRealm()) {
+									context.getSource().sendFeedback(Text.of("RM-R: Due to Realms API being internal, you can not use the /reconnect command."));
+									return 0;
+								}
+
+								// Send feedback to player
+								context.getSource().sendFeedback(Text.of("RM-R: /reconnect command called"));
+
+								// Parse current server address
+								ServerAddress serverAddress = ServerAddress.parse(currentServer.address);
+
+								// Disconnect user
+								client.world.disconnect();
+								client.disconnect();
+
+								// Initiate reconnect sequence
+								client.execute(() -> {
+									ConnectScreen.connect(null, client, serverAddress, currentServer, true, null);
+								});
+
+								return 1;
+							})
+			);
+		});
 	}
 }

--- a/src/main/java/com/xand/reconnectmod/ReconnectModReloaded.java
+++ b/src/main/java/com/xand/reconnectmod/ReconnectModReloaded.java
@@ -38,7 +38,7 @@ public class ReconnectModReloaded implements ClientModInitializer {
 								}
 
 								if (currentServer.isRealm()) {
-									context.getSource().sendFeedback(Text.of("RM-R: Due to Realms API being internal, you can not use the /reconnect command."));
+									context.getSource().sendFeedback(Text.of("RM-R: Due to the Realms API being internal, you can not use the /reconnect command."));
 									return 0;
 								}
 

--- a/src/main/java/com/xand/reconnectmod/mixin/RMixin.java
+++ b/src/main/java/com/xand/reconnectmod/mixin/RMixin.java
@@ -35,13 +35,13 @@ public abstract class RMixin extends Screen {
 
 		// Determine if the player is in a Realms world
 		ServerInfo currentServer = this.client.getCurrentServerEntry();
-		if (currentServer != null && currentServer.address != null && currentServer.address.endsWith(".realms.minecraft.net")) {
+		if (currentServer != null && currentServer.address != null && currentServer.isRealm()) {
 			inRealms = true;
 		}
 
-		// Execute if-statement if the user is not in a singleplayer world
+		// If the player is neither in singleplayer nor in Realms, add the reconnect button
 		if (!inSingleplayer && !inRealms) {
-			LOGGER.info(ANSI_YELLOW + "Player not in a singleplayer world, displaying the reconnect button");
+			LOGGER.info(ANSI_YELLOW + "Player not in a singleplayer world or Realms, displaying the reconnect button");
 			MutableText text = (MutableText) Text.of("R");
 			this.addDrawableChild(new ReconnectButtonWidget(
 					this.width / 2 - 102 + 208,
@@ -71,6 +71,8 @@ public abstract class RMixin extends Screen {
 					},
 					(narrationSupplier) -> Text.translatable("reconnectmod.narration.reconnect_button")
 			));
+		} else if (inRealms) {
+			LOGGER.info(ANSI_YELLOW + "Player is in a Realms world, hiding the reconnect button.");
 		}
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
 	"icon": "assets/reconnect-mod-reloaded/icon.png",
 	"environment": "*",
 	"entrypoints": {
-		"main": [
+		"client": [
 			"com.xand.reconnectmod.ReconnectModReloaded"
 		],
 		"fabric-datagen": [
@@ -34,8 +34,8 @@
 		"reconnect-mod-reloaded.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.15.11",
-		"minecraft": ">=1.21",
+		"fabricloader": ">=0.16.14",
+		"minecraft": ">=1.21 <1.22",
 		"java": ">=21"
 	},
 	"suggests": {


### PR DESCRIPTION
Implements #3.

Gives players the ability to reconnect from a multiplayer server using _**/reconnect**_ on in-game chat.
_Note: this does not implement anything similar to **/hub** like in most servers. This replicates the same behaviour as what the button from the pause menu screen would do._

**FIXES**:
- Properly hide the reconnect button when the player is inside a singleplayer world or Realms.

**SETBACKS**:
- Despite the initial implementation, this feature is also not accessible on Realms.
- Due to how the Realms API is implemented by Mojang, allowing players to use this mod on a Realm-hosted world is not feasible.