### PR TITLE
Implement command payloading

### DIFF
--- a/buildSrc/src/main/kotlin/BuildConf.kt
+++ b/buildSrc/src/main/kotlin/BuildConf.kt
@@ -1,12 +1,13 @@
 import org.gradle.api.Project
 
 object BuildConf {
+
     const val MINECRAFT_VERSION: String = "26.1"
     const val FABRIC_LOADER_VERSION: String = "0.18.4"
     const val FABRIC_API_VERSION: String = "0.144.0+26.1"
     const val NEOFORGE_VERSION: String = "26.1.0.1-beta"
 
-    var MOD_VERSION: String = "1.5"
+    var MOD_VERSION: String = "2.0"
 
     fun getVersionString(project: Project): String {
         val builder = StringBuilder()
@@ -15,4 +16,5 @@ object BuildConf {
 
         return builder.toString()
     }
+
 }

--- a/buildSrc/src/main/kotlin/BuildConf.kt
+++ b/buildSrc/src/main/kotlin/BuildConf.kt
@@ -6,7 +6,7 @@ object BuildConf {
     const val FABRIC_API_VERSION: String = "0.144.0+26.1"
     const val NEOFORGE_VERSION: String = "26.1.0.1-beta"
 
-    var MOD_VERSION: String = "1.4"
+    var MOD_VERSION: String = "1.5"
 
     fun getVersionString(project: Project): String {
         val builder = StringBuilder()

--- a/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
+++ b/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
@@ -50,6 +50,8 @@ public class ReconnectHandler {
                     RealmsMainScreen.play(RealmsStateManager.currentRealm, currentScreen);
                 });
 
+                if (ArgumentUtils.getPostCommand() == null) sendSuccessMessage();
+
                 return 1;
             } else {
                 isReconnecting = false; // Abort reconnect state if fetching fails
@@ -69,6 +71,8 @@ public class ReconnectHandler {
         client.execute(() -> {
             ConnectScreen.startConnecting(currentScreen, client, serverAddress, currentServer, true, null);
         });
+
+        if (ArgumentUtils.getPostCommand() == null) sendSuccessMessage();
 
         return 1;
     }

--- a/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
+++ b/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
@@ -1,6 +1,7 @@
 package io.xa59.reconnect;
 
 import com.mojang.realmsclient.RealmsMainScreen;
+import io.xa59.reconnect.utils.ArgumentUtils;
 import io.xa59.reconnect.utils.RealmsStateManager;
 import io.xa59.reconnect.utils.StatusDisplay;
 import net.minecraft.ChatFormatting;
@@ -12,8 +13,6 @@ import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.network.chat.Component;
 
 public class ReconnectHandler {
-    private static boolean reconnectTriggered = false;
-
     public static int reconnect(Minecraft instance) {
         Minecraft client = Minecraft.getInstance();
         ServerData currentServer = client.getCurrentServer();
@@ -30,7 +29,7 @@ public class ReconnectHandler {
 
         // Disconnect user
         if (client.level != null) {
-            client.level.disconnect(Component.literal("[Reconnect]: User requested reconnect sequence using /reconnect."));
+            client.level.disconnect(Component.literal("[Reconnect] User requested reconnect sequence using /reconnect."));
         }
 
         Screen currentScreen = client.screen;
@@ -65,6 +64,7 @@ public class ReconnectHandler {
         });
 
         sendSuccessMessage();
+
         return 1;
     }
 
@@ -74,11 +74,25 @@ public class ReconnectHandler {
         StatusDisplay.resetOverlay();
     }
 
-    public static boolean wasTriggered() {
-        return reconnectTriggered;
-    }
+    public static void handlePostJoin(Minecraft client) {
+        String commandToRun = ArgumentUtils.getPostCommand();
+        int delayTime = ArgumentUtils.getDelaySeconds();
 
-    public static void reset() {
-        reconnectTriggered = false;
+        if (commandToRun == null) return;
+
+        // Clear shared state
+        ArgumentUtils.clear();
+
+        new Thread(() -> {
+            try {
+                Thread.sleep(delayTime * 1000L); // sleep() expects milliseconds, convert value
+            } catch (InterruptedException ignored) {}
+
+            client.execute(() -> {
+                if (client.player != null) {
+                    client.player.connection.sendCommand(commandToRun);
+                }
+            });
+        }).start();
     }
 }

--- a/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
+++ b/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
@@ -112,7 +112,7 @@ public class ReconnectHandler {
 
         new Thread(() -> {
             try {
-                Thread.sleep(delayTime * 1000L);
+                Thread.sleep(Math.max(200, delayTime * 1000L));
             } catch (InterruptedException ignored) {}
 
             client.execute(() -> {

--- a/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
+++ b/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
@@ -17,7 +17,7 @@ public class ReconnectHandler {
     // Flag to track if a reconnect is actually in progress and prevent multiple event fires
     private static boolean isReconnecting = false;
 
-    public static int reconnect(Minecraft instance) {
+    public static int reconnect() {
         Minecraft client = Minecraft.getInstance();
         ServerData currentServer = client.getCurrentServer();
 
@@ -46,9 +46,7 @@ public class ReconnectHandler {
         // If on Realms, handle connection through here instead
         if (currentServer.isRealm()) {
             if (RealmsStateManager.currentRealm != null) {
-                client.execute(() -> {
-                    RealmsMainScreen.play(RealmsStateManager.currentRealm, currentScreen);
-                });
+                client.execute(() -> RealmsMainScreen.play(RealmsStateManager.currentRealm, currentScreen));
 
                 if (ArgumentUtils.getPostCommand() == null) sendSuccessMessage();
 
@@ -68,9 +66,7 @@ public class ReconnectHandler {
         // Parse current server address
         ServerAddress serverAddress = ServerAddress.parseString(currentServer.ip);
 
-        client.execute(() -> {
-            ConnectScreen.startConnecting(currentScreen, client, serverAddress, currentServer, true, null);
-        });
+        client.execute(() -> ConnectScreen.startConnecting(currentScreen, client, serverAddress, currentServer, true, null));
 
         if (ArgumentUtils.getPostCommand() == null) sendSuccessMessage();
 
@@ -131,4 +127,5 @@ public class ReconnectHandler {
             });
         }).start();
     }
+
 }

--- a/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
+++ b/common/src/main/java/io/xa59/reconnect/ReconnectHandler.java
@@ -13,6 +13,10 @@ import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.network.chat.Component;
 
 public class ReconnectHandler {
+
+    // Flag to track if a reconnect is actually in progress and prevent multiple event fires
+    private static boolean isReconnecting = false;
+
     public static int reconnect(Minecraft instance) {
         Minecraft client = Minecraft.getInstance();
         ServerData currentServer = client.getCurrentServer();
@@ -26,6 +30,9 @@ public class ReconnectHandler {
             }
             return 0;
         }
+
+        // Mark that an intentional reconnect sequence has started
+        isReconnecting = true;
 
         // Disconnect user
         if (client.level != null) {
@@ -43,9 +50,9 @@ public class ReconnectHandler {
                     RealmsMainScreen.play(RealmsStateManager.currentRealm, currentScreen);
                 });
 
-                sendSuccessMessage();
                 return 1;
             } else {
+                isReconnecting = false; // Abort reconnect state if fetching fails
                 if (client.player != null) {
                     client.player.sendOverlayMessage(
                             Component.literal("Failed to fetch Realm data for reconnect.")
@@ -63,8 +70,6 @@ public class ReconnectHandler {
             ConnectScreen.startConnecting(currentScreen, client, serverAddress, currentServer, true, null);
         });
 
-        sendSuccessMessage();
-
         return 1;
     }
 
@@ -75,22 +80,49 @@ public class ReconnectHandler {
     }
 
     public static void handlePostJoin(Minecraft client) {
+        // Abort if not triggered by command, or if it already ran
+        if (!isReconnecting) {
+            return;
+        }
+
+        // Consume the intent so this logic only executes exactly once
+        isReconnecting = false;
+
         String commandToRun = ArgumentUtils.getPostCommand();
         int delayTime = ArgumentUtils.getDelaySeconds();
-
-        if (commandToRun == null) return;
 
         // Clear shared state
         ArgumentUtils.clear();
 
+        assert client.player != null;
+
+        // If null or empty
+        if (commandToRun == null || commandToRun.trim().isEmpty()) {
+            sendSuccessMessage();
+            return;
+        }
+
+        // If command exists with delay, display intent overlay message
+        if (delayTime != 0) {
+            client.player.sendOverlayMessage(
+                    Component.literal("Successfully reconnected. Running command payload after " + delayTime + " seconds.")
+                            .withStyle(ChatFormatting.YELLOW)
+            );
+        }
+
         new Thread(() -> {
             try {
-                Thread.sleep(delayTime * 1000L); // sleep() expects milliseconds, convert value
+                Thread.sleep(delayTime * 1000L);
             } catch (InterruptedException ignored) {}
 
             client.execute(() -> {
                 if (client.player != null) {
                     client.player.connection.sendCommand(commandToRun);
+
+                    client.player.sendOverlayMessage(
+                            Component.literal("Command execution complete.")
+                                    .withStyle(ChatFormatting.GREEN)
+                    );
                 }
             });
         }).start();

--- a/common/src/main/java/io/xa59/reconnect/mixin/PauseMenuMixin.java
+++ b/common/src/main/java/io/xa59/reconnect/mixin/PauseMenuMixin.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(PauseScreen.class)
 public abstract class PauseMenuMixin extends Screen {
+
     protected PauseMenuMixin(Component title) {
         super(title);
     }
@@ -52,10 +53,11 @@ public abstract class PauseMenuMixin extends Screen {
         this.addRenderableWidget(
                 Button.builder(
                         Component.literal("R"),
-                                _ -> ReconnectHandler.reconnect(minecraft)
+                                _ -> ReconnectHandler.reconnect()
                 )
                 .bounds(x, y, bW, bH)
                 .build()
         );
     }
+
 }

--- a/common/src/main/java/io/xa59/reconnect/mixin/RealmsMainScreenMixin.java
+++ b/common/src/main/java/io/xa59/reconnect/mixin/RealmsMainScreenMixin.java
@@ -11,8 +11,10 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(RealmsMainScreen.class)
 public class RealmsMainScreenMixin {
-    @Inject(method = "play(Lcom/mojang/realmsclient/dto/RealmsServer;Lnet/minecraft/client/gui/screens/Screen;)V", at = @At("HEAD"), remap = true)
+
+    @Inject(method = "play(Lcom/mojang/realmsclient/dto/RealmsServer;Lnet/minecraft/client/gui/screens/Screen;)V", at = @At("HEAD"))
     private static void captureRealmData(RealmsServer server, Screen lastScreen, CallbackInfo ci) {
         RealmsStateManager.currentRealm = server;
     }
+
 }

--- a/common/src/main/java/io/xa59/reconnect/utils/ArgumentUtils.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/ArgumentUtils.java
@@ -1,0 +1,42 @@
+package io.xa59.reconnect.utils;
+
+public class ArgumentUtils {
+    private static String postCommand;
+    private static int delaySeconds;
+
+    public static String cleanupCommandInput(String input) {
+        if (input == null) return null;
+
+        input = input.trim();
+
+        // Remove surrounding quotes
+        if (input.startsWith("\"") && input.endsWith("\"") && input.length() >= 2) {
+            input = input.substring(1, input.length() - 1);
+        }
+
+        // Remove leading slash
+        if (input.startsWith("/")) {
+            input = input.substring(1);
+        }
+
+        return input;
+    }
+
+    // Setter for postCommand
+    public static void setPostCommand(String cmd) { postCommand = cmd; }
+
+    // Getter for postCommand
+    public static String getPostCommand() { return postCommand; }
+
+    // Setter for delaySeconds
+    public static void setDelay(String input) { delaySeconds = TimeParser.parseTime(input); }
+
+    // Getter for delaySeconds
+    public static int getDelaySeconds() { return delaySeconds; }
+
+    // Clears shared state
+    public static void clear() {
+        postCommand = null;
+        delaySeconds = 0;
+    }
+}

--- a/common/src/main/java/io/xa59/reconnect/utils/ArgumentUtils.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/ArgumentUtils.java
@@ -1,6 +1,7 @@
 package io.xa59.reconnect.utils;
 
 public class ArgumentUtils {
+
     private static String postCommand;
     private static int delaySeconds;
 
@@ -39,4 +40,5 @@ public class ArgumentUtils {
         postCommand = null;
         delaySeconds = 0;
     }
+
 }

--- a/common/src/main/java/io/xa59/reconnect/utils/IStatusDisplay.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/IStatusDisplay.java
@@ -3,6 +3,8 @@ package io.xa59.reconnect.utils;
 import net.minecraft.ChatFormatting;
 
 public interface IStatusDisplay {
+
     void sendOverlayMessageAfterJoin(String message, ChatFormatting formatting);
     void resetOverlay();
+
 }

--- a/common/src/main/java/io/xa59/reconnect/utils/RealmsStateManager.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/RealmsStateManager.java
@@ -3,5 +3,7 @@ package io.xa59.reconnect.utils;
 import com.mojang.realmsclient.dto.RealmsServer;
 
 public class RealmsStateManager {
+
     public static RealmsServer currentRealm = null;
+
 }

--- a/common/src/main/java/io/xa59/reconnect/utils/StatusDisplay.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/StatusDisplay.java
@@ -3,6 +3,7 @@ package io.xa59.reconnect.utils;
 import net.minecraft.ChatFormatting;
 
 public class StatusDisplay {
+
     private static IStatusDisplay impl;
 
     public static void setImplementation(IStatusDisplay implementation) {
@@ -20,4 +21,5 @@ public class StatusDisplay {
             impl.resetOverlay();
         }
     }
+
 }

--- a/common/src/main/java/io/xa59/reconnect/utils/TimeParser.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/TimeParser.java
@@ -1,6 +1,7 @@
 package io.xa59.reconnect.utils;
 
 public class TimeParser {
+
     public static int parseTime(String input) {
         input = input.toLowerCase().trim();
 
@@ -22,4 +23,5 @@ public class TimeParser {
             return 0;
         }
     }
+
 }

--- a/common/src/main/java/io/xa59/reconnect/utils/TimeParser.java
+++ b/common/src/main/java/io/xa59/reconnect/utils/TimeParser.java
@@ -1,0 +1,25 @@
+package io.xa59.reconnect.utils;
+
+public class TimeParser {
+    public static int parseTime(String input) {
+        input = input.toLowerCase().trim();
+
+        try {
+            if (input.endsWith("s")) { // Seconds
+                return Integer.parseInt(input.replace("s", ""));
+            }
+
+            if (input.endsWith("m")) { // Minutes
+                return Integer.parseInt(input.replace("m", "")) * 60;
+            }
+
+            if (input.endsWith("t")) { // Ticks
+                return Integer.parseInt(input.replace("t", "")) / 20;
+            }
+
+            return Integer.parseInt(input);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+}

--- a/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
+++ b/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
@@ -1,13 +1,18 @@
 package io.xa59.reconnect;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
 import io.xa59.reconnect.utils.FabricStatusDisplay;
 import io.xa59.reconnect.utils.StatusDisplay;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.minecraft.client.Minecraft;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
+import net.minecraft.network.chat.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.xa59.reconnect.utils.ArgumentUtils;
 
 public class ReconnectFabricMod implements ClientModInitializer {
 	public static final String MOD_ID = "reconnect";
@@ -24,11 +29,59 @@ public class ReconnectFabricMod implements ClientModInitializer {
 		StatusDisplay.setImplementation(new FabricStatusDisplay());
 
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, _) -> {
-			// Register the /reconnect command
 			dispatcher.register(
 					ClientCommands.literal("reconnect")
-							.executes(_ -> ReconnectHandler.reconnect(Minecraft.getInstance()))
+							.then(ClientCommands.literal("execute")
+
+									// "/reconnect execute <command>"
+									.then(ClientCommands.argument("command", StringArgumentType.greedyString())
+											.executes(ctx -> {
+												String cmd = StringArgumentType.getString(ctx, "command");
+												cmd = ArgumentUtils.cleanupCommandInput(cmd);
+
+												if (cmd == null || cmd.isEmpty()) {
+													ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
+													return 0;
+												}
+
+												ArgumentUtils.setPostCommand(cmd);
+
+												// Ensure delay is reset when not provided
+												ArgumentUtils.setDelay("0s");
+
+												return ReconnectHandler.reconnect(Minecraft.getInstance());
+											})
+									)
+
+									// "/reconnect execute delay <time> <command>"
+									.then(ClientCommands.literal("delay")
+											.then(ClientCommands.argument("time", StringArgumentType.word())
+													.then(ClientCommands.argument("command", StringArgumentType.greedyString())
+															.executes(ctx -> {
+																String cmd = StringArgumentType.getString(ctx, "command");
+																cmd = ArgumentUtils.cleanupCommandInput(cmd);
+
+																String time = StringArgumentType.getString(ctx, "time");
+
+																if (cmd == null || cmd.isEmpty()) {
+																	ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
+																	return 0;
+																}
+
+																ArgumentUtils.setPostCommand(cmd);
+																ArgumentUtils.setDelay(time);
+
+																return ReconnectHandler.reconnect(Minecraft.getInstance());
+															})
+													)
+											)
+									)
+							)
 			);
+		});
+
+		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
+			ReconnectHandler.handlePostJoin(client);
 		});
 	}
 }

--- a/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
+++ b/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
@@ -40,7 +40,14 @@ public class ReconnectFabricMod implements ClientModInitializer {
                                             String cmd = StringArgumentType.getString(ctx, "command");
                                             cmd = ArgumentUtils.cleanupCommandInput(cmd);
 
-                                            if (cmd == null || cmd.isEmpty()) {
+                                            String[] parts = cmd.trim().split("\\s+");
+
+                                            if (parts.length > 0 && parts[0].equalsIgnoreCase("reconnect")) {
+                                                ctx.getSource().sendError(Component.literal("<59xa> bro, don't even try recursing /reconnect lmfao"));
+                                                return 0;
+                                            }
+
+                                            if (cmd.isEmpty()) {
                                                 ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
                                                 return 0;
                                             }

--- a/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
+++ b/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
@@ -31,6 +31,8 @@ public class ReconnectFabricMod implements ClientModInitializer {
 		ClientCommandRegistrationCallback.EVENT.register((dispatcher, _) -> {
 			dispatcher.register(
 					ClientCommands.literal("reconnect")
+							.executes(_ -> ReconnectHandler.reconnect(Minecraft.getInstance()))
+
 							.then(ClientCommands.literal("execute")
 
 									// "/reconnect execute <command>"

--- a/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
+++ b/fabric/src/main/java/io/xa59/reconnect/ReconnectFabricMod.java
@@ -6,7 +6,6 @@ import io.xa59.reconnect.utils.StatusDisplay;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.minecraft.client.Minecraft;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommands;
 import net.minecraft.network.chat.Component;
 import org.slf4j.Logger;
@@ -15,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import io.xa59.reconnect.utils.ArgumentUtils;
 
 public class ReconnectFabricMod implements ClientModInitializer {
+
 	public static final String MOD_ID = "reconnect";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
@@ -28,62 +28,59 @@ public class ReconnectFabricMod implements ClientModInitializer {
 
 		StatusDisplay.setImplementation(new FabricStatusDisplay());
 
-		ClientCommandRegistrationCallback.EVENT.register((dispatcher, _) -> {
-			dispatcher.register(
-					ClientCommands.literal("reconnect")
-							.executes(_ -> ReconnectHandler.reconnect(Minecraft.getInstance()))
+		ClientCommandRegistrationCallback.EVENT.register((dispatcher, _) -> dispatcher.register(
+                ClientCommands.literal("reconnect")
+                        .executes(_ -> ReconnectHandler.reconnect())
 
-							.then(ClientCommands.literal("execute")
+                        .then(ClientCommands.literal("execute")
 
-									// "/reconnect execute <command>"
-									.then(ClientCommands.argument("command", StringArgumentType.greedyString())
-											.executes(ctx -> {
-												String cmd = StringArgumentType.getString(ctx, "command");
-												cmd = ArgumentUtils.cleanupCommandInput(cmd);
+                                // "/reconnect execute <command>"
+                                .then(ClientCommands.argument("command", StringArgumentType.greedyString())
+                                        .executes(ctx -> {
+                                            String cmd = StringArgumentType.getString(ctx, "command");
+                                            cmd = ArgumentUtils.cleanupCommandInput(cmd);
 
-												if (cmd == null || cmd.isEmpty()) {
-													ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
-													return 0;
-												}
+                                            if (cmd == null || cmd.isEmpty()) {
+                                                ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
+                                                return 0;
+                                            }
 
-												ArgumentUtils.setPostCommand(cmd);
+                                            ArgumentUtils.setPostCommand(cmd);
 
-												// Ensure delay is reset when not provided
-												ArgumentUtils.setDelay("0s");
+                                            // Ensure delay is reset when not provided
+                                            ArgumentUtils.setDelay("0s");
 
-												return ReconnectHandler.reconnect(Minecraft.getInstance());
-											})
-									)
+                                            return ReconnectHandler.reconnect();
+                                        })
+                                )
 
-									// "/reconnect execute delay <time> <command>"
-									.then(ClientCommands.literal("delay")
-											.then(ClientCommands.argument("time", StringArgumentType.word())
-													.then(ClientCommands.argument("command", StringArgumentType.greedyString())
-															.executes(ctx -> {
-																String cmd = StringArgumentType.getString(ctx, "command");
-																cmd = ArgumentUtils.cleanupCommandInput(cmd);
+                                // "/reconnect execute delay <time> <command>"
+                                .then(ClientCommands.literal("delay")
+                                        .then(ClientCommands.argument("time", StringArgumentType.word())
+                                                .then(ClientCommands.argument("command", StringArgumentType.greedyString())
+                                                        .executes(ctx -> {
+                                                            String cmd = StringArgumentType.getString(ctx, "command");
+                                                            cmd = ArgumentUtils.cleanupCommandInput(cmd);
 
-																String time = StringArgumentType.getString(ctx, "time");
+                                                            String time = StringArgumentType.getString(ctx, "time");
 
-																if (cmd == null || cmd.isEmpty()) {
-																	ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
-																	return 0;
-																}
+                                                            if (cmd == null || cmd.isEmpty()) {
+                                                                ctx.getSource().sendError(Component.literal("[Reconnect] Command cannot be empty."));
+                                                                return 0;
+                                                            }
 
-																ArgumentUtils.setPostCommand(cmd);
-																ArgumentUtils.setDelay(time);
+                                                            ArgumentUtils.setPostCommand(cmd);
+                                                            ArgumentUtils.setDelay(time);
 
-																return ReconnectHandler.reconnect(Minecraft.getInstance());
-															})
-													)
-											)
-									)
-							)
-			);
-		});
+                                                            return ReconnectHandler.reconnect();
+                                                        })
+                                                )
+                                        )
+                                )
+                        )
+        ));
 
-		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {
-			ReconnectHandler.handlePostJoin(client);
-		});
+		ClientPlayConnectionEvents.JOIN.register((_, _, client) -> ReconnectHandler.handlePostJoin(client));
 	}
+
 }

--- a/fabric/src/main/java/io/xa59/reconnect/utils/FabricStatusDisplay.java
+++ b/fabric/src/main/java/io/xa59/reconnect/utils/FabricStatusDisplay.java
@@ -5,6 +5,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 
 public class FabricStatusDisplay implements IStatusDisplay {
+
     private boolean showOverlay = false;
 
     @Override
@@ -23,4 +24,5 @@ public class FabricStatusDisplay implements IStatusDisplay {
     public void resetOverlay() {
         showOverlay = false;
     }
+
 }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -42,8 +42,6 @@ val mainJar = tasks.register<Jar>("mainJar") {
     filesMatching(listOf("META-INF/neoforge.mods.toml")) {
         expand(mapOf("version" to inputs.properties["version"]))
     }
-
-    archiveClassifier = "main"
 }
 
 val configurationMod: Configuration = configurations.create("main") {

--- a/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
+++ b/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
@@ -52,6 +52,8 @@ public class ReconnectNeoForgeMod {
         // Register the /reconnect command
         event.getDispatcher().register(
                 Commands.literal("reconnect")
+                        .executes(_ -> ReconnectHandler.reconnect(Minecraft.getInstance()))
+
                         .then(Commands.literal("execute")
 
                                 // "/reconnect execute <command>"

--- a/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
+++ b/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
@@ -61,7 +61,14 @@ public class ReconnectNeoForgeMod {
                                             String cmd = StringArgumentType.getString(ctx, "command");
                                             cmd = ArgumentUtils.cleanupCommandInput(cmd);
 
-                                            if (cmd == null || cmd.isEmpty()) {
+                                            String[] parts = cmd.trim().split("\\s+");
+
+                                            if (parts.length > 0 && parts[0].equalsIgnoreCase("reconnect")) {
+                                                ctx.getSource().sendFailure(Component.literal("<59xa> bro, don't even try recursing /reconnect lmfao"));
+                                                return 0;
+                                            }
+
+                                            if (cmd.isEmpty()) {
                                                 ctx.getSource().sendFailure(Component.literal("[Reconnect] Command cannot be empty."));
                                                 return 0;
                                             }

--- a/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
+++ b/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
@@ -1,8 +1,12 @@
 package io.xa59.reconnect;
 
+import com.mojang.brigadier.arguments.StringArgumentType;
+import io.xa59.reconnect.utils.ArgumentUtils;
 import io.xa59.reconnect.utils.NeoForgeStatusDisplay;
 import io.xa59.reconnect.utils.StatusDisplay;
+import net.minecraft.network.chat.Component;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
 import net.neoforged.neoforge.client.event.lifecycle.ClientStartedEvent;
 import org.slf4j.Logger;
 
@@ -29,16 +33,71 @@ public class ReconnectNeoForgeMod {
         StatusDisplay.setImplementation(new NeoForgeStatusDisplay());
     }
 
+    @SubscribeEvent
+    public void onJoin(ClientPlayerNetworkEvent.LoggingIn event) {
+        Minecraft client = Minecraft.getInstance();
+
+        client.execute(() -> {
+            ReconnectHandler.handlePostJoin(client);
+        });
+    }
+
     public ReconnectNeoForgeMod() {
         NeoForge.EVENT_BUS.register(this);
         NeoForge.EVENT_BUS.addListener(this::registerCommands);
+        NeoForge.EVENT_BUS.addListener(this::onJoin);
     }
 
     private void registerCommands(RegisterClientCommandsEvent event) {
         // Register the /reconnect command
         event.getDispatcher().register(
                 Commands.literal("reconnect")
-                        .executes(_ -> ReconnectHandler.reconnect(Minecraft.getInstance()))
+                        .then(Commands.literal("execute")
+
+                                // "/reconnect execute <command>"
+                                .then(Commands.argument("command", StringArgumentType.greedyString())
+                                        .executes(ctx -> {
+                                            String cmd = StringArgumentType.getString(ctx, "command");
+                                            cmd = ArgumentUtils.cleanupCommandInput(cmd);
+
+                                            if (cmd == null || cmd.isEmpty()) {
+                                                ctx.getSource().sendFailure(Component.literal("[Reconnect] Command cannot be empty."));
+                                                return 0;
+                                            }
+
+                                            ArgumentUtils.setPostCommand(cmd);
+
+                                            // Ensure delay is reset when not provided
+                                            ArgumentUtils.setDelay("0s");
+
+                                            return ReconnectHandler.reconnect(Minecraft.getInstance());
+                                        })
+                                )
+
+                                // "/reconnect execute delay <time> <command>"
+                                .then(Commands.literal("delay")
+                                        .then(Commands.argument("time", StringArgumentType.word())
+                                                .then(Commands.argument("command", StringArgumentType.greedyString())
+                                                        .executes(ctx -> {
+                                                            String cmd = StringArgumentType.getString(ctx, "command");
+                                                            cmd = ArgumentUtils.cleanupCommandInput(cmd);
+
+                                                            String time = StringArgumentType.getString(ctx, "time");
+
+                                                            if (cmd == null || cmd.isEmpty()) {
+                                                                ctx.getSource().sendFailure(Component.literal("[Reconnect] Command cannot be empty."));
+                                                                return 0;
+                                                            }
+
+                                                            ArgumentUtils.setPostCommand(cmd);
+                                                            ArgumentUtils.setDelay(time);
+
+                                                            return ReconnectHandler.reconnect(Minecraft.getInstance());
+                                                        })
+                                                )
+                                        )
+                                )
+                        )
         );
     }
 }

--- a/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
+++ b/neoforge/src/main/java/io/xa59/reconnect/ReconnectNeoForgeMod.java
@@ -20,6 +20,7 @@ import net.neoforged.neoforge.common.NeoForge;
 
 @Mod(value = "reconnect", dist = Dist.CLIENT)
 public class ReconnectNeoForgeMod {
+
     public static final Logger LOGGER = LogUtils.getLogger();
 
     public static final String ANSI_RESET = "\u001B[0m";
@@ -37,9 +38,7 @@ public class ReconnectNeoForgeMod {
     public void onJoin(ClientPlayerNetworkEvent.LoggingIn event) {
         Minecraft client = Minecraft.getInstance();
 
-        client.execute(() -> {
-            ReconnectHandler.handlePostJoin(client);
-        });
+        client.execute(() -> ReconnectHandler.handlePostJoin(client));
     }
 
     public ReconnectNeoForgeMod() {
@@ -52,7 +51,7 @@ public class ReconnectNeoForgeMod {
         // Register the /reconnect command
         event.getDispatcher().register(
                 Commands.literal("reconnect")
-                        .executes(_ -> ReconnectHandler.reconnect(Minecraft.getInstance()))
+                        .executes(_ -> ReconnectHandler.reconnect())
 
                         .then(Commands.literal("execute")
 
@@ -72,7 +71,7 @@ public class ReconnectNeoForgeMod {
                                             // Ensure delay is reset when not provided
                                             ArgumentUtils.setDelay("0s");
 
-                                            return ReconnectHandler.reconnect(Minecraft.getInstance());
+                                            return ReconnectHandler.reconnect();
                                         })
                                 )
 
@@ -94,7 +93,7 @@ public class ReconnectNeoForgeMod {
                                                             ArgumentUtils.setPostCommand(cmd);
                                                             ArgumentUtils.setDelay(time);
 
-                                                            return ReconnectHandler.reconnect(Minecraft.getInstance());
+                                                            return ReconnectHandler.reconnect();
                                                         })
                                                 )
                                         )
@@ -102,4 +101,5 @@ public class ReconnectNeoForgeMod {
                         )
         );
     }
+
 }

--- a/neoforge/src/main/java/io/xa59/reconnect/utils/NeoForgeStatusDisplay.java
+++ b/neoforge/src/main/java/io/xa59/reconnect/utils/NeoForgeStatusDisplay.java
@@ -11,6 +11,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 
 @EventBusSubscriber(value = Dist.CLIENT, modid = "reconnect")
 public class NeoForgeStatusDisplay implements IStatusDisplay {
+
     private boolean showOverlay = false;
 
     @Override
@@ -32,4 +33,5 @@ public class NeoForgeStatusDisplay implements IStatusDisplay {
     public void resetOverlay() {
         showOverlay = false;
     }
+
 }


### PR DESCRIPTION
Implements #5 

### How to use?
User can add command payloads using the following signatures: 
- **`/reconnect execute <command>`** or 
- **`/reconnect execute delay [time] <command>`**

User can add a command payload with or without forward slash, for example:
- **`/reconnect execute lobby bedwars`** or
- **`/reconnect execute /lobby bedwars`**

### Payload interval
User is given an option to add a delay to their payload call, delay time can be defined by `seconds (s)`, `minutes (m)`, and/or `ticks (t)`.
For example: `/reconnect execute delay 5s lobby`

### Additional information
- User is notified through overlay message whether the command payload is being executed
- User is also notified when the mod finishes executing the command payload

### Restrictions
- Inaccessible for the reconnect button
- Payload recursion is not allowed
  - This means the user is not allowed to do the following: **`/reconnect execute reconnect execute reconnect`**, this for example throws an error feedback